### PR TITLE
OneWheelDriveTask Ceiling Method & TwoWheelDirectDrivetrain Null Pointer Exception Fix

### DIFF
--- a/java/team25core/OneWheelDriveTask.java
+++ b/java/team25core/OneWheelDriveTask.java
@@ -44,9 +44,11 @@ public class OneWheelDriveTask extends RobotTask
 
     public double right;
     public double left;
+    public double ceiling;
 
     public boolean slow = false;
     public boolean useLeftJoystick = false;
+    public boolean ceilingOn = false;
 
     public double slowMultiplier = 0.5;
 
@@ -93,15 +95,37 @@ public class OneWheelDriveTask extends RobotTask
         robot.removeTask(this);
     }
 
+    public void useCeiling(double ceiling)
+    {
+        ceilingOn = true;
+        this.ceiling = ceiling;
+    }
+
     @Override
     public boolean timeslice()
     {
         getJoystick();
 
         if (useLeftJoystick) {
-           motor.setPower(left);
+           if (ceilingOn) {
+               if (left > ceiling) {
+                   motor.setPower(ceiling);
+               } else {
+                   motor.setPower(left);
+               }
+           } else {
+               motor.setPower(left);
+           }
         } else {
-            motor.setPower(right);
+            if (ceilingOn) {
+                if (right > ceiling) {
+                    motor.setPower(ceiling);
+                } else {
+                    motor.setPower(right);
+                }
+            } else {
+                motor.setPower(right);
+            }
         }
 
         if (slow) {
@@ -112,6 +136,8 @@ public class OneWheelDriveTask extends RobotTask
 
         robot.telemetry.addData("L: ", left);
         robot.telemetry.addData("R: ", right);
+
+        //robot.telemetry.addData("Lift Encoder: ", motor.getCurrentPosition());
 
         return false;
     }

--- a/java/team25core/TwoWheelDirectDrivetrain.java
+++ b/java/team25core/TwoWheelDirectDrivetrain.java
@@ -74,6 +74,8 @@ public class TwoWheelDirectDrivetrain extends DrivetrainBaseImpl implements Driv
         this.alternate = true;
 
         frontRight.setDirection(DcMotor.Direction.REVERSE);
+
+        setMasterMotor(frontLeft);
     }
 
     @Override


### PR DESCRIPTION
We fixed two wheel drive direction constructor, which was causing a null pointer exception. The fix was tested. We added useCeiling method in OneWheelDriveTask to allow for a constant speed. Was tested.