### PR TITLE
Prevent sending of duplicate events.

### DIFF
--- a/java/team25core/DeadReckonTask.java
+++ b/java/team25core/DeadReckonTask.java
@@ -249,7 +249,7 @@ public class DeadReckonTask extends RobotTask {
             dr.stop();
             drivetrain.stop();
             return true;
-        } else if (segment.state == DeadReckonPath.SegmentState.DONE) {
+        } else if ((segment.state == DeadReckonPath.SegmentState.DONE) && (dr.numSegments() > 1)) {
             if (reason == DoneReason.ENCODER_REACHED) {
                 RobotLog.e("251 Dead reckon segment %d done", num);
                 robot.queueEvent(new DeadReckonEvent(this, EventKind.SEGMENT_DONE, num));


### PR DESCRIPTION
If we were using a sensor to short-circuit a dead reckon path, and the path only had one segment, or we were currently consuming the last segment in the path, then software would send two events if the sensor criteria were satisfied.

This is because when the criteria is satisfied we set the segment state to DONE, while in the WAIT state, this causes an event to be sent the next time timeslice() is called because of line 252 in the diff below, then we remove the segment that is done, the path list is now empty and a second event is sent before the task determines that it's finished and stops entirely. 